### PR TITLE
Return dendrogram from binary_cut

### DIFF
--- a/R/cluster.R
+++ b/R/cluster.R
@@ -46,6 +46,7 @@ cluster_terms = function(mat, method = "binary_cut", control = list(), catch_err
 	if(verbose) message(qq("Cluster @{nrow(mat)} terms by '@{method}'..."), appendLF = FALSE)
 	flush.console()
 
+	if(method == "binary_cut") control$return_dend = FALSE
 	fun = get_clustering_method(method, control = control)
 	
 	t1 = Sys.time()
@@ -61,16 +62,13 @@ cluster_terms = function(mat, method = "binary_cut", control = list(), catch_err
 		}
 	}
 
-	t_diff = t2 - t1
-	t_diff = format(t_diff)
+	t_diff = format(t2 - t1)
 	if(verbose) message(qq(" @{length(unique(cl))} clusters, used @{t_diff}."))
 
 	if(length(unique(cl)) > 1) {
 		if(method != "binary_cut") {
 			#reorder the class labels
-			class_mean = tapply(1:nrow(mat), cl, function(ind) {
-				colMeans(mat[ind, , drop = FALSE])
-			})
+			class_mean = tapply(1:nrow(mat), cl, function(ind) colMeans(mat[ind, , drop = FALSE]))
 			class_mean = do.call(rbind, class_mean)
 			ns = nrow(class_mean)
 
@@ -83,7 +81,6 @@ cluster_terms = function(mat, method = "binary_cut", control = list(), catch_err
 	}
 
 	attr(cl, "running_time") = t_diff
-
 	return(cl)
 }
 


### PR DESCRIPTION
After seeing I could not retrieve the dendrogram created by `binary_cut` (#78 ) I propose the following pull request where:

1. I added `return_dend = FALSE` to both `cluster_mat` and `cluster_mat2` (in the one there was already such an argument which was not in use)
1. Moved the `cl = as.numeric(as.vector(unname(cl)))` line into these functions (instead of in `binary_cut`)
2. Changed functions to return either just `cl` or a named list of `cl` and `dend`.
3. Documentation and `plot_binary_cut` updated accordingly

Lastly, in `cluster_terms`, as all clustering methods must return a vector of clusters, I added that `return_dend=FALSE`. I think this should be removed and that returning a more complex object could be nice but that is a bigger change than I intended.

I tested the changes over my data and saw no problems