### PR TITLE
Increase simplifyGOFromMultipleLists bar plot width

### DIFF
--- a/R/simplify.R
+++ b/R/simplify.R
@@ -317,7 +317,7 @@ simplifyGOFromMultipleLists = function(lt, go_id_column = NULL,
 				left_annotation = rowAnnotation(
 					empty = anno_block(width = unit(1.2, "cm"), panel_fun = function(index) grid.text(qq("Number of significant GO terms in each cluster (padj < @{padj_cutoff})"), unit(0, "npc"), 0.5, just = "top", rot = 90, gp = gpar(fontsize = 10))),
 					bar = anno_link(
-						align_to = align_to, side = "left", gap = unit(3, "mm"),
+						align_to = align_to, side = "left", gap = unit(3, "mm"), width=unit(0.5, "cm")*n,
 						link_gp = gpar(fill = "#DDDDDD", col = "#AAAAAA"), internal_line = FALSE,
 						panel_fun = function(index) {
 							v = apply(mm[index, ], 2, function(x) sum(x >= transform(padj_cutoff)))


### PR DESCRIPTION
Set width of bar plot anno_link as 0.5 cm per group - the same as the Padj heatmap.

Perhaps not suited for the default branch, but fixes an issue with overlapping labels when plotting a number of groups with simplifyGOFromMultipleLists.

![Screenshot 2024-09-23 182143](https://github.com/user-attachments/assets/889e47cf-1ba0-43dc-bed2-d639efe11069)
